### PR TITLE
Security infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+.gradle
+.tmp
+build
 node_modules
+npm-debug.log

--- a/bin/mltap
+++ b/bin/mltap
@@ -48,7 +48,14 @@ client.eval(bootstrap,
       process.exit(0);
     },
     error => { 
-      process.stderr.write(error.body.errorResponse.message + '\n'); 
+      // console.dir(error);
+      if('SEC-PRIV' === error.body.errorResponse.messageCode) {
+        process.stderr.write('Are you sure you configured the security settings? ');
+        process.stderr.write('mltap requires roles, amps, and privileges.\n');
+        process.stderr.write('\nFrom where you downloaded mltap, run:\n');
+        process.stderr.write('    gradle mlDeploy\n');
+      }
+      process.stderr.write('\n' + error.body.errorResponse.message + '\n'); 
       process.exit(1); 
     }
   );

--- a/bin/mltap
+++ b/bin/mltap
@@ -21,11 +21,11 @@ const opts = require('docopt').docopt(doc);
 
 const marklogic = require('marklogic');
 const conn = {
-  host: 'localhost',  // TODO: Parameterize me
-  port: '8000',       // TODO: Parameterize me
-  user: 'admin',      // TODO: Parameterize me
-  password: 'admin',  // TODO: Parameterize me 
-  authType: 'digest', // TODO: Parameterize me
+  host:     'localhost',  // TODO: Parameterize me
+  port:     '8000',       // TODO: Parameterize me
+  user:     'tester',     // TODO: Parameterize me
+  password: 'tester',     // TODO: Parameterize me 
+  authType: 'digest',     // TODO: Parameterize me
 }
 const client = marklogic.createDatabaseClient(conn);
 
@@ -43,22 +43,12 @@ client.eval(bootstrap,
     tests: opts['<test>'], //['test/test.test.sjs', 'test/lib.test.sjs',]
   })
   .result(
-    response => process.stdout.write(response[0].value + '\n'),
-    error => { console.dir(error); process.exit(1); }
+    response => {
+      process.stdout.write(response[0].value + '\n');
+      process.exit(0);
+    },
+    error => { 
+      process.stderr.write(error.body.errorResponse.message + '\n'); 
+      process.exit(1); 
+    }
   );
-
-// const http = require('http');
-
-// const request = require('request');
-
-// request.post('http://localhost:8992/remote.sjs', {
-//   auth: {
-//     user: 'admin',
-//     pass: 'admin',
-//     sendImmediately: false,
-//   },
-//   headers: {
-//     'Content-Type': 'application/x-www-form-urlencoded'
-//   },
-//   body: opts['<test>'].map(item => `tests=${item}`).join('&'),
-// }, (error, response, body) => console.log(body));

--- a/bin/mltap
+++ b/bin/mltap
@@ -34,13 +34,9 @@ const client = marklogic.createDatabaseClient(conn);
  *   Array<string> tests - The paths to the tests, relative to the root
  *   string root - The root context to resolve module imports. Assumes file system
  */
-const bootstrap = `
-  'use strict';
-  xdmp.invokeFunction(function() {
-    return require('/mltap/mltap')(tests);
-  }, {modules: 0, root: root});`;
+const bootstrap = `require('/mltap/mltap')(tests, root, 0);`;
 
-// TODO: Figure out the minimum privileges and/or how to amp
+// TODO: Figure out 
 client.eval(bootstrap, 
   {
     root: process.cwd(), //'/Users/jmakeig/Workspaces/tmptest', 
@@ -48,7 +44,7 @@ client.eval(bootstrap,
   })
   .result(
     response => process.stdout.write(response[0].value + '\n'),
-    error => process.exit(1)
+    error => { console.dir(error); process.exit(1); }
   );
 
 // const http = require('http');

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,12 @@
+buildscript {
+  repositories {
+    mavenCentral()
+    mavenLocal()
+    jcenter()
+  }
+  dependencies {
+    classpath "com.marklogic:ml-gradle:2.3.2"
+  }
+}
+
+apply plugin: 'com.marklogic.ml-gradle'

--- a/config/marklogic/security/amps/mltap-runner.json
+++ b/config/marklogic/security/amps/mltap-runner.json
@@ -1,0 +1,7 @@
+{
+  "local-name": "runner",
+  "document-uri": "/mltap/mltap.js",
+  "role": [
+    "mltap-internal"
+  ]
+}

--- a/config/marklogic/security/privileges/mltap-runner.json
+++ b/config/marklogic/security/privileges/mltap-runner.json
@@ -2,7 +2,5 @@
   "privilege-name": "mltap-runner",
   "action": "http://github.com/jmakeig/mltap/runner",
   "kind": "execute",
-  "role": [
-    "mltap-tester"
-  ]
+  "role": [ ]
 }

--- a/config/marklogic/security/privileges/mltap-runner.json
+++ b/config/marklogic/security/privileges/mltap-runner.json
@@ -1,0 +1,8 @@
+{
+  "privilege-name": "mltap-runner",
+  "action": "http://github.com/jmakeig/mltap/runner",
+  "kind": "execute",
+  "role": [
+    "mltap-tester"
+  ]
+}

--- a/config/marklogic/security/roles/mltap-internal.json
+++ b/config/marklogic/security/roles/mltap-internal.json
@@ -1,0 +1,21 @@
+{
+  "role-name": "mltap-internal",
+  "description": "mltap interal role used *only* for amping. Do not assign this to a user.",
+  "privilege": [
+    {
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke",
+      "kind": "execute",
+      "privilege-name": "xdmp:invoke"
+    },
+    {
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke-modules-change-file",
+      "kind": "execute",
+      "privilege-name": "xdmp:invoke-modules-change-file"
+    },
+    {
+      "action": "http://marklogic.com/xdmp/privileges/xdmp-invoke-modules-change",
+      "kind": "execute",
+      "privilege-name": "xdmp:invoke-modules-change"
+    }
+  ]
+}

--- a/config/marklogic/security/roles/mltap-tester.json
+++ b/config/marklogic/security/roles/mltap-tester.json
@@ -1,11 +1,16 @@
 {
   "role-name": "mltap-tester",
-  "description": "",
+  "description": "Required role for running mltap tests.",
   "privilege": [
     {
       "action": "http://marklogic.com/xdmp/privileges/xdbc-eval",
       "kind": "execute",
       "privilege-name": "xdbc:eval"
+    },
+    {
+      "action": "http://github.com/jmakeig/mltap/runner",
+      "kind": "execute",
+      "privilege-name": "mltap-runner"
     }
   ]
 }

--- a/config/marklogic/security/roles/mltap-tester.json
+++ b/config/marklogic/security/roles/mltap-tester.json
@@ -1,0 +1,11 @@
+{
+  "role-name": "mltap-tester",
+  "description": "",
+  "privilege": [
+    {
+      "action": "http://marklogic.com/xdmp/privileges/xdbc-eval",
+      "kind": "execute",
+      "privilege-name": "xdbc:eval"
+    }
+  ]
+}

--- a/config/marklogic/security/users/tester.json
+++ b/config/marklogic/security/users/tester.json
@@ -1,0 +1,8 @@
+{
+  "user-name": "tester",
+  "description": "Dummy test user. Instead of this one, you should apply the mltap-test role to your own users.",
+  "role": [
+    "mltap-tester"
+  ],
+  "password": "tester"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+mlHost=localhost
+mlAppName=mltap
+mlAdminUsername=admin
+mlAdminPassword=admin
+mlConfigDir=config/marklogic

--- a/mltap.js
+++ b/mltap.js
@@ -20,6 +20,7 @@
  * @returns {string} TAP 13 output
  */
 function runner(tests, root, modules) {
+  xdmp.securityAssert(['http://github.com/jmakeig/mltap/runner'], 'execute');
   const results = [];
   const ctx = {
     root: root,

--- a/mltap.js
+++ b/mltap.js
@@ -18,10 +18,15 @@
  * @param {Array<string>} tests
  * @returns {string} TAP 13 output
  */
-function runner(tests) {
+function runner(tests, root, modules) {
   const results = [];
+  const ctx = {
+    root: root,
+    modules: modules || 0,
+    ignoreAmps: false,
+  }
   for(let test of tests) {
-    let harness = fn.head(xdmp.invoke(test));
+    let harness = fn.head(xdmp.invoke(test, null, ctx));
     harness.run();
     results.push(
       {

--- a/mltap.js
+++ b/mltap.js
@@ -9,6 +9,7 @@
 
 /**
  * Run the tests at the referenced paths and return a TAP string.
+ * Must be amped to the mltap-internal role.
  * 
  * @example
  * 'use strict';
@@ -104,4 +105,4 @@ function asTAP(results) {
   return out.join('\n');
 }
 
-module.exports = runner;
+module.exports = module.amp(runner);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
     "test": "test"
   },
   "scripts": {
-    "test": "tape test/**.test.sjs"
+    "test-marklogic": "bin/mltap test/**.test.sjs",
+    "test-marklogic-pretty": "bin/mltap test/**.test.sjs | tap-notify | tap-diff",
+    "test-node": "tape test/**.test.sjs",
+    "test-node-pretty": "tape test/**.test.sjs | tap-notify | tap-diff",
+    "test-browser": "echo 'Not yet implemented'; exit 1;",
+    "test": "echo '\n\nRunning tests with mltap in MarkLogic\n'; bin/mltap test/**.test.sjs && echo '\n\nRunning tests with tape in Node\n'; tape test/**.test.sjs",
+    "config": "gradle mlDeploy && mkdir -p ~/Library/MarkLogic/Modules/mltap; cp -R mltap.js test.js lib ~/Library/MarkLogic/Modules/mltap/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #10: 
- `mltap-tester` and `mltap-internal` roles
- `mltap-runner` privilege to `mltap-tester`, checked in outer `eval`
- `/mltap/mltap.js` amped to `mltap-internal` to do `invoke` for tests on file system root
- Gradle deployment. Fixes rjrudin/ml-app-deployer#114.
