### PR TITLE
Adds CI support with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - nvm install $NODE_VERSION
   - ./scripts/install-dependencies.sh
   - npm install
+# TRAVIS_BUILD_DIR=/home/travis/build/jmakeig/mltap
   - if [ -z ${ML_HOME+x} ]; then echo 'The environment variable ML_HOME is empty or missing' && exit 1; else sudo mkdir -p "$ML_HOME/Modules/mltap"; sudo cp -R mltap.js test.js lib "$ML_HOME/Modules/mltap/"; fi
   - npm run config
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ before_install:
   - echo 'America/Los_Angeles' | sudo tee /etc/timezone
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
 install:
+  - pwd
   - nvm install $NODE_VERSION
-  - sudo /home/travis/.nvm/versions/node/v6.5.0/bin/npm help
-#  - ./scripts/install-dependencies.sh
+  - ./scripts/install-dependencies.sh
   - npm install
-  - sudo npm run config
+  - if [ -z ${ML_HOME+x} ]; then echo 'The environment variable ML_HOME is empty or missing' && exit 1; else sudo mkdir -p "$ML_HOME/Modules/mltap"; sudo cp -R mltap.js test.js lib "$ML_HOME/Modules/mltap/"; fi
+  - npm run config
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+  - master
+  - develop
 language: node_js
 node_js:
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
 node_js:
   - "6"
+sudo: true
+before_install:
+  - echo 'America/Los_Angeles' | sudo tee /etc/timezone
+  - sudo dpkg-reconfigure --frontend noninteractive tzdata
+install:
+  - ./scripts/install-dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
   - master
   - develop
+  - travis
 language: node_js
 node_js:
   - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ before_install:
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
 install:
   - ./scripts/install-dependencies.sh
+script:
+  - npm install && npm config

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ install:
   - nvm install $NODE_VERSION
   - ./scripts/install-dependencies.sh
   - npm install
-  - npm run config
+  - sudo npm run config
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ before_install:
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
 install:
   - nvm install $NODE_VERSION
+  - echo $(type -P npm)
 #  - ./scripts/install-dependencies.sh
   - npm install
-  - type -P npm
   - sudo npm run config
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,20 @@ branches:
   - master
   - develop
   - travis
-language: node_js
-node_js:
-  - "6"
+# <https://github.com/travis-ci/travis-ci/issues/3827#issuecomment-98114873>
+language: java
+jdk:
+  - oraclejdk8
 sudo: true
+env:
+  - NODE_VERSION=6.5
 before_install:
   - echo 'America/Los_Angeles' | sudo tee /etc/timezone
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
 install:
+  - nvm install $NODE_VERSION
   - ./scripts/install-dependencies.sh
+  - npm install
+  - npm run config
 script:
-  - npm install && npm config
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ before_install:
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
 install:
   - nvm install $NODE_VERSION
-  - ./scripts/install-dependencies.sh
+#  - ./scripts/install-dependencies.sh
   - npm install
+  - type -P npm
   - sudo npm run config
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
 install:
   - nvm install $NODE_VERSION
-  - echo $(type -P npm)
+  - sudo /home/travis/.nvm/versions/node/v6.5.0/bin/npm help
 #  - ./scripts/install-dependencies.sh
   - npm install
   - sudo npm run config

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## mltap
+## mltap [![Build Status](https://travis-ci.org/jmakeig/mltap.svg?branch=develop)](https://travis-ci.org/jmakeig/mltap)
 
 A (partial) implementation of the [tape](https://github.com/substack/tape) API. This allows you to run the same tests in Node.js or MarkLogic with no modifications to the test code. (Currently you do have to adjust the `require` imports at the start of each test to run them in MarkLogic).
 `mltap` produces [TAP](https://testanything.org) output so you can use it the other tools that can consume TAP. 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-pretty": "tape test/*.test.js | tap-notify | tap-diff",
     "test-marklogic": "bin/mltap test/*.test.sjs",
     "test-marklogic-pretty": "bin/mltap test/*.test.sjs | tap-notify | tap-diff",
-    "config": "gradle mlDeploy && npm run deploy",
+    "config": "gradle mlDeploy",
     "deploy": "npm run env && mkdir -p \"$ML_HOME/Modules/mltap\"; cp -R mltap.js test.js lib \"$ML_HOME/Modules/mltap/\"",
     "env": "if [ -z ${ML_HOME+x} ]; then echo 'The environment variable ML_HOME is empty or missing' && exit 1; else echo $ML_HOME; fi"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-pretty": "tape test/*.test.js | tap-notify | tap-diff",
     "test-marklogic": "bin/mltap test/*.test.sjs",
     "test-marklogic-pretty": "bin/mltap test/*.test.sjs | tap-notify | tap-diff",
-    "config": "gradle mlDeploy && npm deploy",
+    "config": "gradle mlDeploy && npm run deploy",
     "deploy": "npm run env && mkdir -p \"$ML_HOME/Modules/mltap\"; cp -R mltap.js test.js lib \"$ML_HOME/Modules/mltap/\"",
     "env": "if [ -z ${ML_HOME+x} ]; then echo 'The environment variable ML_HOME is empty or missing' && exit 1; else echo $ML_HOME; fi"
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/jmakeig/mltap#readme",
   "devDependencies": {
     "tap-out": "^1.4.2",
+    "tap-parser": "^2.2.1",
     "tape": "^4.6.0",
     "tape-catch": "^1.0.6"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test-marklogic": "bin/mltap test/*.test.sjs",
     "test-marklogic-pretty": "bin/mltap test/*.test.sjs | tap-notify | tap-diff",
     "config": "gradle mlDeploy && npm deploy",
-    "deploy": "mkdir -p ~/Library/MarkLogic/Modules/mltap; cp -R mltap.js test.js lib ~/Library/MarkLogic/Modules/mltap/"
+    "deploy": "npm run env && mkdir -p \"$ML_HOME/Modules/mltap\"; cp -R mltap.js test.js lib \"$ML_HOME/Modules/mltap/\"",
+    "env": "if [ -z ${ML_HOME+x} ]; then echo 'The environment variable ML_HOME is empty or missing' && exit 1; else echo $ML_HOME; fi"
   },
   "repository": {
     "type": "git",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,6 @@
+Scripts to instantiate the test environment in Travis-CI.
+
+### Environment Variables
+* `MLBUILD_USER` (secure): The user who authenticates the download 
+* `MLBUILD_PASSWORD` (secure): The password to authenticate `MLBUILD_USER`
+* `ML_HOME`: Where MarkLogic is installed, specifically to write to the `Modules` directory. `/opt/MarkLogic` on Linux and `~/Library/MarkLogic` on OS X

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ "${TRAVIS_SECURE_ENV_VARS}" = "true" ] ; then
+  ./shared/dev-tasks/travis-install-ml.sh release
+  ./shared/dev-tasks/setup-marklogic.sh
+fi

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ "${TRAVIS_SECURE_ENV_VARS}" = "true" ] ; then
-  ./shared/dev-tasks/travis-install-ml.sh release
+  ./shared/dev-tasks/travis-install-ml.sh nightly
   ./shared/dev-tasks/setup-marklogic.sh
 fi

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ "${TRAVIS_SECURE_ENV_VARS}" = "true" ] ; then
-  ./scripts/travis-install-ml.sh nightly
+  ./scripts/travis-install-ml.sh
   ./scripts/setup-marklogic.sh
 fi

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ "${TRAVIS_SECURE_ENV_VARS}" = "true" ] ; then
-  ./shared/dev-tasks/travis-install-ml.sh nightly
-  ./shared/dev-tasks/setup-marklogic.sh
+  ./scripts/travis-install-ml.sh nightly
+  ./scripts/setup-marklogic.sh
 fi

--- a/scripts/setup-marklogic.sh
+++ b/scripts/setup-marklogic.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+sudo /etc/init.d/MarkLogic start
+sleep 10
+curl -X POST -d "" http://localhost:8001/admin/v1/init
+sleep 10
+curl -X POST -H "Content-type: application/x-www-form-urlencoded" \
+     --data "admin-username=admin" \
+     --data "admin-password=admin" \
+     --data "realm=public" \
+     "http://localhost:8001/admin/v1/instance-admin"
+sleep 10

--- a/scripts/travis-install-ml.sh
+++ b/scripts/travis-install-ml.sh
@@ -58,9 +58,9 @@ else
   fnamedeb=$fnamedeb$suff
 
   #url="https://root.marklogic.com/nightly/builds/linux64/rh6-intel64-80-test-1.marklogic.com/b8_0/pkgs.$day/$fname"
-  url="https://root.marklogic.com/nightly/builds/linux64/rh6v-intel64-90-test-1.marklogic.com/HEAD/pkgs.$day/MarkLogic-RHEL6-$fname.x86_64.rpm"
+  url="https://root.marklogic.com/nightly/builds/linux64/rh6v-intel64-90-test-1.marklogic.com/HEAD/pkgs.$day/MarkLogic-RHEL6-$fname"
   echo "$url"
-  
+
   status=$(curl -k --anyauth -u $MLBUILD_USER:$MLBUILD_PASSWORD --head --write-out %{http_code} --silent --output /dev/null $url)
   if [[ $status = 200 ]]; then
     successOrExit curl -k --anyauth -u $MLBUILD_USER:$MLBUILD_PASSWORD -o ./$fname $url

--- a/scripts/travis-install-ml.sh
+++ b/scripts/travis-install-ml.sh
@@ -51,14 +51,15 @@ else
   echo "********* Downloading MarkLogic nightly $ver"
 
   # fetch/install ML nightly
-  fname="MarkLogic-$ver.x86_64.rpm"
+  #fname="MarkLogic-$ver.x86_64.rpm"
+  fname="MarkLogic-RHEL6-$ver.x86_64.rpm"
   fnamedeb="marklogic_"
   fnamedeb=$fnamedeb$ver
   suff="_amd64.deb"
   fnamedeb=$fnamedeb$suff
 
   #url="https://root.marklogic.com/nightly/builds/linux64/rh6-intel64-80-test-1.marklogic.com/b8_0/pkgs.$day/$fname"
-  url="https://root.marklogic.com/nightly/builds/linux64/rh6v-intel64-90-test-1.marklogic.com/HEAD/pkgs.$day/MarkLogic-RHEL6-$fname"
+  url="https://root.marklogic.com/nightly/builds/linux64/rh6v-intel64-90-test-1.marklogic.com/b9_0/pkgs.$day/$fname"
   echo "$url"
 
   status=$(curl -k --anyauth -u $MLBUILD_USER:$MLBUILD_PASSWORD --head --write-out %{http_code} --silent --output /dev/null $url)

--- a/scripts/travis-install-ml.sh
+++ b/scripts/travis-install-ml.sh
@@ -45,7 +45,8 @@ else
   # if the user passed a day string as a param then use it instead
   test $1 && day=$1
   # make a version number out of the date
-  ver="8.0-$day"
+  #ver="8.0-$day"
+  ver="9.0-$day"
 
   echo "********* Downloading MarkLogic nightly $ver"
 
@@ -56,8 +57,10 @@ else
   suff="_amd64.deb"
   fnamedeb=$fnamedeb$suff
 
-  url="https://root.marklogic.com/nightly/builds/linux64/rh6-intel64-80-test-1.marklogic.com/b8_0/pkgs.$day/$fname"
-
+  #url="https://root.marklogic.com/nightly/builds/linux64/rh6-intel64-80-test-1.marklogic.com/b8_0/pkgs.$day/$fname"
+  url="https://root.marklogic.com/nightly/builds/linux64/rh6v-intel64-90-test-1.marklogic.com/HEAD/pkgs.$day/MarkLogic-RHEL6-$fname.x86_64.rpm"
+  echo "$url"
+  
   status=$(curl -k --anyauth -u $MLBUILD_USER:$MLBUILD_PASSWORD --head --write-out %{http_code} --silent --output /dev/null $url)
   if [[ $status = 200 ]]; then
     successOrExit curl -k --anyauth -u $MLBUILD_USER:$MLBUILD_PASSWORD -o ./$fname $url

--- a/scripts/travis-install-ml.sh
+++ b/scripts/travis-install-ml.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# runs command from parameters and exits with the eoror code of the command
+# if it fails
+function successOrExit {
+    "$@"
+    local status=$?
+    if [ $status -ne 0 ]; then
+        echo "$1 exited with error: $status"
+        exit $status
+    fi
+}
+
+set | grep TRAVIS
+
+test $1 && arg1=$1
+if [[ $arg1 = 'release' ]]; then
+  ver=${ML_VERSION}
+  fname=MarkLogic-RHEL6-${ver}.x86_64.rpm
+  fnamedeb="marklogic_"
+  fnamedeb=$fnamedeb$ver
+  suff="_amd64.deb"
+  fnamedeb=$fnamedeb$suff
+
+  curl -c cookies.txt --data "email=${MLBUILD_USER}&password=${MLBUILD_PASSWORD}" https://developer.marklogic.com/login
+  dl_link=$(curl -b cookies.txt --data "download=/download/binaries/8.0/${fname}" https://developer.marklogic.com/get-download-url | perl -pe 's/.*"path":"([^"]+).*/\1/')
+  url="https://developer.marklogic.com${dl_link}"
+
+  echo "********* Downloading MarkLogic $ver"
+
+  successOrExit curl -k -o ./$fname $url
+
+  fname=$(pwd)/$fname
+
+  sudo apt-get update
+  sudo apt-get install wajig alien rpm lsb-base dpkg-dev debhelper build-essential
+  (cd /etc && sudo ln -s default sysconfig)
+  sudo wajig rpminstall $fname
+
+  echo "********* MarkLogic $ver installed"
+else
+  # find today
+  day=$(date +"%Y%m%d")
+
+  # if the user passed a day string as a param then use it instead
+  test $1 && day=$1
+  # make a version number out of the date
+  ver="8.0-$day"
+
+  echo "********* Downloading MarkLogic nightly $ver"
+
+  # fetch/install ML nightly
+  fname="MarkLogic-$ver.x86_64.rpm"
+  fnamedeb="marklogic_"
+  fnamedeb=$fnamedeb$ver
+  suff="_amd64.deb"
+  fnamedeb=$fnamedeb$suff
+
+  url="https://root.marklogic.com/nightly/builds/linux64/rh6-intel64-80-test-1.marklogic.com/b8_0/pkgs.$day/$fname"
+
+  status=$(curl -k --anyauth -u $MLBUILD_USER:$MLBUILD_PASSWORD --head --write-out %{http_code} --silent --output /dev/null $url)
+  if [[ $status = 200 ]]; then
+    successOrExit curl -k --anyauth -u $MLBUILD_USER:$MLBUILD_PASSWORD -o ./$fname $url
+
+    fname=$(pwd)/$fname
+
+    sudo apt-get update
+    sudo apt-get install alien dpkg-dev debhelper build-essential
+    sudo alien -d -k $fname
+    sudo dpkg -i $fnamedeb
+
+    echo "********* MarkLogic nightly $ver installed"
+  else
+    echo "CANNOT DOWNLOAD: status = $status for date $day (URL=\"$url\")"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
Fixes #18: Installs MarkLogic and the other dependencies in the Travis container and runs the tests. It’s currently brittle because I’m developing on OS X and Travis runs on Ubuntu. (Completely untested on Windows.) For example, writing to `$ML_HOME/Modules` requires `root` on Linux. `sudo` doesn't know about `nvm` and thus `npm`, etc.

There may be future opportunities to improve this with Docker on Travis (#23).
