### PR TITLE
Fixes #19 with better serialization of types

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -5,3 +5,7 @@ Copyright (c) 2011 Felix Geisendörfer (felix@debuggable.com)
 node-deep-equal
 <https://github.com/substack/node-deep-equal>
 MIT
+
+object-inspect
+<https://github.com/substack/object-inspect>
+MIT

--- a/lib/object-inspect.js
+++ b/lib/object-inspect.js
@@ -1,0 +1,207 @@
+var hasMap = typeof Map === 'function' && Map.prototype;
+var mapSizeDescriptor = Object.getOwnPropertyDescriptor && hasMap ? Object.getOwnPropertyDescriptor(Map.prototype, 'size') : null;
+var mapSize = hasMap && mapSizeDescriptor && typeof mapSizeDescriptor.get === 'function' ? mapSizeDescriptor.get : null;
+var mapForEach = hasMap && Map.prototype.forEach;
+var hasSet = typeof Set === 'function' && Set.prototype;
+var setSizeDescriptor = Object.getOwnPropertyDescriptor && hasSet ? Object.getOwnPropertyDescriptor(Set.prototype, 'size') : null;
+var setSize = hasSet && setSizeDescriptor && typeof setSizeDescriptor.get === 'function' ? setSizeDescriptor.get : null;
+var setForEach = hasSet && Set.prototype.forEach;
+var booleanValueOf = Boolean.prototype.valueOf;
+
+module.exports = function inspect_ (obj, opts, depth, seen) {
+    if (!opts) opts = {};
+    
+    var maxDepth = opts.depth === undefined ? 5 : opts.depth;
+    if (depth === undefined) depth = 0;
+    if (depth >= maxDepth && maxDepth > 0 && obj && typeof obj === 'object') {
+        return '[Object]';
+    }
+    
+    if (seen === undefined) seen = [];
+    else if (indexOf(seen, obj) >= 0) {
+        return '[Circular]';
+    }
+    
+    function inspect (value, from) {
+        if (from) {
+            seen = seen.slice();
+            seen.push(from);
+        }
+        return inspect_(value, opts, depth + 1, seen);
+    }
+    
+    if (typeof obj === 'string') {
+        return inspectString(obj);
+    }
+    else if (typeof obj === 'function') {
+        var name = nameOf(obj);
+        return '[Function' + (name ? ': ' + name : '') + ']';
+    }
+    else if (obj === null) {
+        return 'null';
+    }
+    else if (isSymbol(obj)) {
+        var symString = Symbol.prototype.toString.call(obj);
+        return typeof obj === 'object' ? 'Object(' + symString + ')' : symString;
+    }
+    else if (isElement(obj)) {
+        var s = '<' + String(obj.nodeName).toLowerCase();
+        var attrs = obj.attributes || [];
+        for (var i = 0; i < attrs.length; i++) {
+            s += ' ' + attrs[i].name + '="' + quote(attrs[i].value) + '"';
+        }
+        s += '>';
+        if (obj.childNodes && obj.childNodes.length) s += '...';
+        s += '</' + String(obj.nodeName).toLowerCase() + '>';
+        return s;
+    }
+    else if (isArray(obj)) {
+        if (obj.length === 0) return '[]';
+        var xs = Array(obj.length);
+        for (var i = 0; i < obj.length; i++) {
+            xs[i] = has(obj, i) ? inspect(obj[i], obj) : '';
+        }
+        return '[ ' + xs.join(', ') + ' ]';
+    }
+    else if (isError(obj)) {
+        var parts = [];
+        for (var key in obj) {
+            if (!has(obj, key)) continue;
+            
+            if (/[^\w$]/.test(key)) {
+                parts.push(inspect(key) + ': ' + inspect(obj[key]));
+            }
+            else {
+                parts.push(key + ': ' + inspect(obj[key]));
+            }
+        }
+        if (parts.length === 0) return '[' + obj + ']';
+        return '{ [' + obj + '] ' + parts.join(', ') + ' }';
+    }
+    else if (typeof obj === 'object' && typeof obj.inspect === 'function') {
+        return obj.inspect();
+    }
+    else if (isMap(obj)) {
+        var parts = [];
+        mapForEach.call(obj, function (value, key) {
+            parts.push(inspect(key, obj) + ' => ' + inspect(value, obj));
+        });
+        return 'Map (' + mapSize.call(obj) + ') {' + parts.join(', ') + '}';
+    }
+    else if (isSet(obj)) {
+        var parts = [];
+        setForEach.call(obj, function (value ) {
+            parts.push(inspect(value, obj));
+        });
+        return 'Set (' + setSize.call(obj) + ') {' + parts.join(', ') + '}';
+    }
+    else if (typeof obj !== 'object') {
+        return String(obj);
+    }
+    else if (isNumber(obj)) {
+        return 'Object(' + Number(obj) + ')';
+    }
+    else if (isBoolean(obj)) {
+        return 'Object(' + booleanValueOf.call(obj) + ')';
+    }
+    else if (isString(obj)) {
+        return 'Object(' + inspect(String(obj)) + ')';
+    }
+    else if (!isDate(obj) && !isRegExp(obj)) {
+        var xs = [], keys = [];
+        for (var key in obj) {
+            if (has(obj, key)) keys.push(key);
+        }
+        keys.sort();
+        for (var i = 0; i < keys.length; i++) {
+            var key = keys[i];
+            if (/[^\w$]/.test(key)) {
+                xs.push(inspect(key) + ': ' + inspect(obj[key], obj));
+            }
+            else xs.push(key + ': ' + inspect(obj[key], obj));
+        }
+        if (xs.length === 0) return '{}';
+        return '{ ' + xs.join(', ') + ' }';
+    }
+    else return String(obj);
+};
+
+function quote (s) {
+    return String(s).replace(/"/g, '&quot;');
+}
+
+function isArray (obj) { return toStr(obj) === '[object Array]' }
+function isDate (obj) { return toStr(obj) === '[object Date]' }
+function isRegExp (obj) { return toStr(obj) === '[object RegExp]' }
+function isError (obj) { return toStr(obj) === '[object Error]' }
+function isSymbol (obj) { return toStr(obj) === '[object Symbol]' }
+function isString (obj) { return toStr(obj) === '[object String]' }
+function isNumber (obj) { return toStr(obj) === '[object Number]' }
+function isBoolean (obj) { return toStr(obj) === '[object Boolean]' }
+
+var hasOwn = Object.prototype.hasOwnProperty || function (key) { return key in this; };
+function has (obj, key) {
+    return hasOwn.call(obj, key);
+}
+
+function toStr (obj) {
+    return Object.prototype.toString.call(obj);
+}
+
+function nameOf (f) {
+    if (f.name) return f.name;
+    var m = f.toString().match(/^function\s*([\w$]+)/);
+    if (m) return m[1];
+}
+
+function indexOf (xs, x) {
+    if (xs.indexOf) return xs.indexOf(x);
+    for (var i = 0, l = xs.length; i < l; i++) {
+        if (xs[i] === x) return i;
+    }
+    return -1;
+}
+
+function isMap (x) {
+    if (!mapSize) {
+        return false;
+    }
+    try {
+        mapSize.call(x);
+        return true;
+    } catch (e) {}
+    return false;
+}
+
+function isSet (x) {
+    if (!setSize) {
+        return false;
+    }
+    try {
+        setSize.call(x);
+        return true;
+    } catch (e) {}
+    return false;
+}
+
+function isElement (x) {
+    if (!x || typeof x !== 'object') return false;
+    if (typeof HTMLElement !== 'undefined' && x instanceof HTMLElement) {
+        return true;
+    }
+    return typeof x.nodeName === 'string'
+        && typeof x.getAttribute === 'function'
+    ;
+}
+
+function inspectString (str) {
+    var s = str.replace(/(['\\])/g, '\\$1').replace(/[\x00-\x1f]/g, lowbyte);
+    return "'" + s + "'";
+    
+    function lowbyte (c) {
+        var n = c.charCodeAt(0);
+        var x = { 8: 'b', 9: 't', 10: 'n', 12: 'f', 13: 'r' }[n];
+        if (x) return '\\' + x;
+        return '\\x' + (n < 0x10 ? '0' : '') + n.toString(16);
+    }
+}

--- a/mltap.js
+++ b/mltap.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const inspect = require('/mltap/lib/object-inspect');
+
 // const ctx = { modules: 0, root: '/Users/jmakeig/Workspaces/mltap' };
 
 // const tests = [
@@ -42,10 +44,10 @@ function runner(tests, root, modules) {
 }
 
 /**
- * 
+ * Serialize as TAP
  * 
  * @param {Array} results
- * @returns
+ * @returns string
  */
 function asTAP(results) {
   /**
@@ -61,17 +63,30 @@ function asTAP(results) {
     return ' '.repeat(num) + str;
   }
   /**
+   * Encode as YAML
+   * 
    * @param {any} value
    * @returns string YAMLish string
    */
   function yaml(value) {
-    if('object' === typeof value) {
-      return yaml(value.toString());
-    }
     if('string' === typeof value) {
-      return `"${value.replace(/"/g, '\\"')}"`;
+      if(isMultilineString(value)) {
+        return JSON.stringify(value);
+      }
+      return `'${value}'`;
     }
-    return value;
+    return inspect(value);
+  }
+
+  /**
+   * Whether a string contains line breaks.
+   * 
+   * @param {any} str Any string
+   * @returns boolean `false` for non-strings too
+   */
+  function isMultilineString(str) {
+    const re = /[\n\r]/g;
+    return 'string' === typeof str && re.test(str);
   }
 
   let counter = 0;
@@ -80,7 +95,7 @@ function asTAP(results) {
     for(let test of module.tests) {
       out.push(`# ${test.name}`);
       //out.push(`# ${test.duration * 1000}ms`)
-      for(let assertion of test.assertions) {
+      for(const assertion of test.assertions) {
         switch(assertion.type) {
           case 'pass':
             out.push(`ok ${++counter} ${assertion.message}`);

--- a/test.js
+++ b/test.js
@@ -125,7 +125,7 @@ Test.prototype = {
     this.outcomes.push({
       type: 'error', 
       message: error.message, 
-      actual: typeName(error),
+      actual: error,
       at: stack[0].toString(),
       stack: stack 
     });
@@ -185,10 +185,12 @@ Test.prototype = {
     );
   },
   equal(actual, expected, message) {
-    return this.true(
-      expected === actual, 
-      message
-    );
+    if(actual === expected) {
+      this.pass(message);
+    } else {
+      console.log(StackTrace.get()[1]);
+      this.fail(message, expected, actual, StackTrace.get()[1]);
+    }
   },
 
   /**
@@ -215,7 +217,7 @@ Test.prototype = {
       }
     }
     const frame = StackTrace.parse(actual)[0];
-    this.fail(message, typeName(expected), typeName(actual), `${frame.fileName}:${frame.lineNumber}:${frame.columnNumber}`);
+    this.fail(message, expected, actual, `${frame.fileName}:${frame.lineNumber}:${frame.columnNumber}`);
   },
   deepEqual(actual, expected, message) {
     const deepEqual = require('/mltap/lib/deep-equal/deep-equal');

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const test = require('tape-catch');
+const remote = require('../marklogic-remote')(/* connection */);
+const parseTAP = require('../lib/tap-helpers').parseTAP;
+
+test('inspect', (assert) => {
+  assert.plan(11);
+  remote('test/inspect.test.sjs') // CHANGE ME
+    .then((tap) => parseTAP(tap))
+    .then(tap => {
+      const actual = result => result.diag.actual;
+      // console.log(JSON.stringify(tap, null, 2));
+      const results = tap.failures; 
+      assert.equal(actual(results[0]), 'string');
+      assert.equal(actual(results[1]), 'Here is a string with spaces and \n line \n breaks');
+      assert.equal(actual(results[2]), 1000);
+      assert.equal(actual(results[3]), true);
+      assert.deepEqual(actual(results[4]), {a:'A', b:'B'});
+      assert.equal(actual(results[5]), '/\\d+/g');
+      assert.deepEqual(actual(results[6]), [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      assert.equal(actual(results[7]), null);
+      assert.equal(actual(results[8]), 'undefined');
+      assert.deepEqual(actual(results[9]), [{'Function': 'asdf'}]);
+      assert.deepEqual(actual(results[10]), ['Function']);
+    })
+    .catch(error => assert.fail(error));
+});

--- a/test/inspect.test.sjs
+++ b/test/inspect.test.sjs
@@ -1,0 +1,190 @@
+'use strict';
+
+const test = require('./is-marklogic') ? require('/mltap/test') : require('tape-catch');
+
+test('inspect', (assert) => {
+  // All of these are intended to fail
+  // so we can test the serialization of 
+  // various types
+  assert.equal('string', null, 'string');
+  assert.equal('Here is a string with spaces and \n line \n breaks', null, 'string with line breaks');
+  assert.equal(1000, null, 'number');
+  assert.equal(true, null, 'boolean');
+  assert.equal({a: 'A', b: 'B'}, null, 'object');
+  assert.equal(/\d+/g, null, 'regexp');
+  assert.equal([1, 2, 3, 4, 5, 6, 7, 8, 9], null, 'array');
+  assert.equal(null, 14, 'null');
+  assert.equal(undefined, null, 'undefined');
+  assert.equal(function asdf() {}, null, 'function');
+  assert.equal(function() {}, null, 'function, anonymous');
+  try {
+    throw new ReferenceError('asdf');
+  } catch(err) {
+    assert.equal(err, null, 'Error');
+  }
+  assert.end();
+});
+
+
+// MarkLogic 
+/*
+TAP version 13
+# inspect
+not ok 1 string
+  ---
+    operator: TODO
+    expected: "null"
+    actual: "'Here is a string with spaces and \n line \n breaks'"
+    at: "Test.impl (/test/inspect.test.sjs:9:10)"
+  ...
+not ok 2 number
+  ---
+    operator: TODO
+    expected: "null"
+    actual: "1000"
+    at: "Test.impl (/test/inspect.test.sjs:10:10)"
+  ...
+not ok 3 boolean
+  ---
+    operator: TODO
+    expected: "null"
+    actual: "true"
+    at: "Test.impl (/test/inspect.test.sjs:11:10)"
+  ...
+not ok 4 object
+  ---
+    operator: TODO
+    expected: "null"
+    actual: "{ a: 'A', b: 'B' }"
+    at: "Test.impl (/test/inspect.test.sjs:12:10)"
+  ...
+not ok 5 regexp
+  ---
+    operator: TODO
+    expected: "null"
+    actual: "/\d+/g"
+    at: "Test.impl (/test/inspect.test.sjs:13:10)"
+  ...
+not ok 6 array
+  ---
+    operator: TODO
+    expected: "null"
+    actual: "[ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]"
+    at: "Test.impl (/test/inspect.test.sjs:14:10)"
+  ...
+not ok 7 null
+  ---
+    operator: TODO
+    expected: "14"
+    actual: "null"
+    at: "Test.impl (/test/inspect.test.sjs:15:10)"
+  ...
+not ok 8 undefined
+  ---
+    operator: TODO
+    expected: "null"
+    actual: "undefined"
+    at: "Test.impl (/test/inspect.test.sjs:16:10)"
+  ...
+not ok 9 function
+  ---
+    operator: TODO
+    expected: "null"
+    actual: "[Function]"
+    at: "Test.impl (/test/inspect.test.sjs:17:10)"
+  ...
+not ok 10 Error
+  ---
+    operator: TODO
+    expected: "null"
+    actual: "[ReferenceError: asdf]"
+    at: "Test.impl (/test/inspect.test.sjs:21:12)"
+  ...
+
+1..10
+*/
+
+// Node
+/*
+TAP version 13
+# inspect
+not ok 1 string
+  ---
+    operator: equal
+    expected: null
+    actual:   'Here is a string with spaces and \n line \n breaks'
+    at: Test.err (/Users/jmakeig/Workspaces/mltap/test/inspect.test.sjs:9:10)
+  ...
+not ok 2 number
+  ---
+    operator: equal
+    expected: null
+    actual:   1000
+    at: Test.err (/Users/jmakeig/Workspaces/mltap/test/inspect.test.sjs:10:10)
+  ...
+not ok 3 boolean
+  ---
+    operator: equal
+    expected: null
+    actual:   true
+    at: Test.err (/Users/jmakeig/Workspaces/mltap/test/inspect.test.sjs:11:10)
+  ...
+not ok 4 object
+  ---
+    operator: equal
+    expected: |-
+      null
+    actual: |-
+      { a: 'A', b: 'B' }
+    at: Test.err (/Users/jmakeig/Workspaces/mltap/test/inspect.test.sjs:12:10)
+  ...
+not ok 5 regexp
+  ---
+    operator: equal
+    expected: null
+    actual:   /\d+/g
+    at: Test.err (/Users/jmakeig/Workspaces/mltap/test/inspect.test.sjs:13:10)
+  ...
+not ok 6 array
+  ---
+    operator: equal
+    expected: null
+    actual:   [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
+    at: Test.err (/Users/jmakeig/Workspaces/mltap/test/inspect.test.sjs:14:10)
+  ...
+not ok 7 null
+  ---
+    operator: equal
+    expected: 14
+    actual:   null
+    at: Test.err (/Users/jmakeig/Workspaces/mltap/test/inspect.test.sjs:15:10)
+  ...
+not ok 8 undefined
+  ---
+    operator: equal
+    expected: null
+    actual:   undefined
+    at: Test.err (/Users/jmakeig/Workspaces/mltap/test/inspect.test.sjs:16:10)
+  ...
+not ok 9 function
+  ---
+    operator: equal
+    expected: null
+    actual:   [Function]
+    at: Test.err (/Users/jmakeig/Workspaces/mltap/test/inspect.test.sjs:17:10)
+  ...
+not ok 10 Error
+  ---
+    operator: equal
+    expected: |-
+      null
+    actual: |-
+      [ReferenceError: asdf]
+    at: Test.err (/Users/jmakeig/Workspaces/mltap/test/inspect.test.sjs:21:12)
+  ...
+
+1..10
+# tests 10
+# pass  0
+# fail  10
+*/

--- a/test/throws.test.js
+++ b/test/throws.test.js
@@ -14,9 +14,9 @@ test('assert.throws()', (assert) => {
       assert.equal(tap.fail, 1, 'Two total tests fail');
       const failure = tap.failures[0];
       assert.skip(failure.diag.operator, 'throws', 'Operator is throws');
-      assert.equal(failure.diag.expected, 'ReferenceError');
-      assert.equal(failure.diag.actual, 'TypeError');
-      assert.equal(failure.diag.at, '/test/throws.test.sjs:17:19', 'Failure location')
+      assert.deepEqual(failure.diag.expected, [{'Function': 'ReferenceError'}]);
+      assert.deepEqual(failure.diag.actual, [{TypeError: 'Thrown TypeError'}]);
+      assert.equal(failure.diag.at, '/test/throws.test.sjs:20:19', 'Failure location');
     })
     .catch(error => assert.fail(error));
 });

--- a/test/throws.test.sjs
+++ b/test/throws.test.sjs
@@ -3,16 +3,19 @@
 const test = require('./is-marklogic') ? require('/mltap/test') : require('tape-catch');
 
 test('assert.throws()', (assert) => {
+  // Pass
   assert.throws(
     () => { throw new TypeError('Thrown TypeError'); }, 
     TypeError, 
     'Is a TypeError'
   );
+  // Pass
   assert.throws(
     () => { throw new TypeError('Thrown TypeError'); }, 
     Error, 
     'Is an Error'
   );
+  // Fail
   assert.throws(
     () => { throw new TypeError('Thrown TypeError'); }, 
     ReferenceError, 
@@ -20,3 +23,19 @@ test('assert.throws()', (assert) => {
   );
   assert.end();
 });
+
+/*
+TAP version 13
+# assert.throws()
+ok 1 Is a TypeError
+ok 2 Is an Error
+not ok 3 Isn’t a ReferenceError
+  ---
+    operator: TODO
+    expected: "[Function: ReferenceError]"
+    actual: "[TypeError: Thrown TypeError]"
+    at: "/test/throws.test.sjs:20:19"
+  ...
+
+1..3
+*/


### PR DESCRIPTION
Adds object-inspect, like Tape and Node. Tries to keep same—sometimes buggy—behavior as Tape.
