### PR TITLE
Fail faster on errors (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ mltap test/*.test.sjs | tap-diff
 
 const test = isMarkLogic() ? 
                require('/mltap/test') : 
-               require('tape-catch');
+               require('tape');
 
 test('Throws an error after some assertions pass', (assert) => {
   assert.true(true, 'true is true');

--- a/bin/mltap
+++ b/bin/mltap
@@ -40,6 +40,11 @@ remote(opts['<test>'], process.cwd())
       process.stderr.write('\nFrom where you downloaded mltap, run:\n');
       process.stderr.write('    gradle mlDeploy\n');
     }
-    process.stderr.write('\n' + error.body.errorResponse.message + '\n'); 
+    process.stderr.write(error.body.errorResponse.message + '\n') ;
+    if(error.stack) {
+      process.stderr.write(error.stack + '\n');
+    } else {
+      process.stderr.write('No remote error stack to report <https://github.com/marklogic/node-client-api/issues/297>' + '\n');
+    }
     process.exit(1); 
   });

--- a/marklogic-remote.js
+++ b/marklogic-remote.js
@@ -37,10 +37,9 @@ function remote(tests, root = process.cwd()) {
         tests: tests,
         root: root, 
       })
-      .result(response => {
-          resolve(response[0].value);
-        },
-        error => { reject(error); } 
+      .result(
+        response => resolve(response[0].value),
+        error => reject(error) 
       )
   });
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
   "devDependencies": {
     "tap-out": "^1.4.2",
     "tap-parser": "^3.0.3",
-    "tape": "^4.6.0",
-    "tape-catch": "^1.0.6"
+    "tape": "^4.6.0"
   },
   "optionalDependencies": {
     "faucet": "0.0.1",

--- a/test.js
+++ b/test.js
@@ -76,12 +76,8 @@ function Test(name, impl) {
 }
 Test.prototype = {
   run() {
-    try {
-      this.impl(this);
-    } catch(error) {
-      this.error(error);
-      this.isErrored = true;
-    }
+    console.log('About to run…');
+    this.impl(this);
     this.complete();
     return this.report();
   },
@@ -206,6 +202,12 @@ Test.prototype = {
       'deepEqual', 
       message || 'deepEqual', 
       actual, expected);
+  },
+  fail(message) {
+    this.assert(false, message || 'fail');
+  },
+  pass(message) {
+    this.assert(true, message || 'pass');
   },
 }
 

--- a/test/deep-equal.test.js
+++ b/test/deep-equal.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const test = require('tape-catch');
+const test = require('tape');
 const remote = require('../marklogic-remote')(/* connection */);
 const parseTAP = require('../lib/tap-helpers').parseTAP;
 

--- a/test/deep-equal.test.sjs
+++ b/test/deep-equal.test.sjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const test = require('./is-marklogic') ? require('/mltap/test') : require('tape-catch');
+const test = require('./is-marklogic') ? require('/mltap/test') : require('tape');
 
 test('assert.deepEqual()', (assert) => {
   assert.deepEqual({a: 'A'}, {a: 'A'}, 'Deep equal');

--- a/test/inspect.test.js
+++ b/test/inspect.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const test = require('tape-catch');
+const test = require('tape');
 const remote = require('../marklogic-remote')(/* connection */);
 const parseTAP = require('../lib/tap-helpers').parseTAP;
 

--- a/test/inspect.test.sjs
+++ b/test/inspect.test.sjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const test = require('./is-marklogic') ? require('/mltap/test') : require('tape-catch');
+const test = require('./is-marklogic') ? require('/mltap/test') : require('tape');
 
 test('inspect', (assert) => {
   // All of these are intended to fail

--- a/test/throws.test.js
+++ b/test/throws.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const test = require('tape-catch');
+const test = require('tape');
 const remote = require('../marklogic-remote')(/* connection */);
 const parseTAP = require('../lib/tap-helpers').parseTAP;
 

--- a/test/throws.test.sjs
+++ b/test/throws.test.sjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const test = require('./is-marklogic') ? require('/mltap/test') : require('tape-catch');
+const test = require('./is-marklogic') ? require('/mltap/test') : require('tape');
 
 test('assert.throws()', (assert) => {
   // Pass

--- a/test/uncaught-error.test.js
+++ b/test/uncaught-error.test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const test = require('tape');
+const remote = require('../marklogic-remote')(/* connection */);
+const parseTAP = require('../lib/tap-helpers').parseTAP;
+
+test('Fail fast on uncaught error', (assert) => {
+  assert.plan(1);
+  remote('test/uncaught-error.test.sjs') // CHANGE ME
+    .then((tap) => parseTAP(tap))
+    .then(tap => {
+      assert.fail('Should have thrown an error');
+    })
+    .catch(error => assert.true(error instanceof Error, 'Is an Error'));
+});

--- a/test/uncaught-error.test.sjs
+++ b/test/uncaught-error.test.sjs
@@ -1,0 +1,8 @@
+'use strict';
+
+const test = require('./is-marklogic') ? require('/mltap/test') : require('tape');
+
+test('Fail fast on uncaught error', (assert) => {
+  // 
+  throw new Error('Uncaught error');
+});


### PR DESCRIPTION
Removes try/catch around calling the test implementation. The idea is to be more like Node programs that bail on uncaught errors. Tape does this too.
